### PR TITLE
Option to don't orderOut the Window if the app is still active (another Window of the app is keyWindow)

### DIFF
--- a/Classes/OBMenuBarWindow.h
+++ b/Classes/OBMenuBarWindow.h
@@ -35,7 +35,6 @@ extern NSString * const OBMenuBarWindowDidAttachToMenuBar;
 extern NSString * const OBMenuBarWindowDidDetachFromMenuBar;
 
 // Constants
-extern const CGFloat OBMenuBarWindowTitleBarHeight;
 extern const CGFloat OBMenuBarWindowArrowHeight;
 extern const CGFloat OBMenuBarWindowArrowWidth;
 
@@ -121,6 +120,9 @@ extern const CGFloat OBMenuBarWindowArrowWidth;
  icon at which to "snap" the window to the menu bar when dragging (default is
  30.0 pixels). */
 @property (assign) CGFloat snapDistance;
+
+/** Height of the Title Bar */
+@property (assign) CGFloat windowTitleBarHeight;
 
 /** The icon to show in the menu bar. The image should have a maximum height of
  22 pixels (or 44 pixels for retina displays). */

--- a/Classes/OBMenuBarWindow.h
+++ b/Classes/OBMenuBarWindow.h
@@ -102,6 +102,14 @@ extern const CGFloat OBMenuBarWindowArrowWidth;
  is set to `YES`. */
 @property (nonatomic, assign) BOOL attachedToMenuBar;
 
+/** Whether the window should 'orderOut' if looses focus but the app remains active.
+ 
+ Setting this to NO helps in case the window should remain visible if it opens a child Window,
+ like a Preferences Window.
+ Default is YES which will orderOut this Window if it opens another window, even if it is a child Window.
+ */
+@property (nonatomic, assign) BOOL isAllowOrderOutWindowIfAppActive;
+
 /** Whether to hide the "traffic light" window controls when the window is
  attached to the menu bar (default is `YES`). */
 @property (nonatomic, assign) BOOL hideWindowControlsWhenAttached;

--- a/Classes/OBMenuBarWindow.h
+++ b/Classes/OBMenuBarWindow.h
@@ -122,7 +122,7 @@ extern const CGFloat OBMenuBarWindowArrowWidth;
 @property (assign) CGFloat snapDistance;
 
 /** Height of the Title Bar */
-@property (assign) CGFloat windowTitleBarHeight;
+@property (nonatomic, assign) CGFloat windowTitleBarHeight;
 
 /** The icon to show in the menu bar. The image should have a maximum height of
  22 pixels (or 44 pixels for retina displays). */

--- a/Classes/OBMenuBarWindow.m
+++ b/Classes/OBMenuBarWindow.m
@@ -489,7 +489,8 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
             // correct the top position by the 'screen with the MenuBar's height
             //  workaround: without this the window will be off-placed when the user plugs in an external display,
             //      a display with more height
-            midPoint.y = [screenWithMenuBar visibleFrame].size.height;
+            NSRect visibleRect = [screenWithMenuBar visibleFrame];
+            midPoint.y = visibleRect.size.height + visibleRect.origin.y;
         }
         
         NSPoint originPoint = NSMakePoint(midPoint.x - (self.frame.size.width / 2),

--- a/Classes/OBMenuBarWindow.m
+++ b/Classes/OBMenuBarWindow.m
@@ -85,6 +85,7 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
         snapDistance = 30.0;
         hideWindowControlsWhenAttached = YES;
         isDetachable = YES;
+        self.isAllowOrderOutWindowIfAppActive = YES;
         [self initialSetup];
     }
     return self;
@@ -457,7 +458,9 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
 {
     if (self.attachedToMenuBar)
     {
-        [self orderOut:self];
+        if( self.isAllowOrderOutWindowIfAppActive || (!self.isAllowOrderOutWindowIfAppActive && ![NSApp keyWindow]) ) {
+            [self orderOut:self];
+        }
     }
     [[self.contentView superview] setNeedsDisplayInRect:[self titleBarRect]];
 }

--- a/Classes/OBMenuBarWindow.m
+++ b/Classes/OBMenuBarWindow.m
@@ -35,7 +35,7 @@ NSString * const OBMenuBarWindowDidAttachToMenuBar = @"OBMenuBarWindowDidAttachT
 NSString * const OBMenuBarWindowDidDetachFromMenuBar = @"OBMenuBarWindowDidDetachFromMenuBar";
 
 // You can alter these constants to change the appearance of the window
-const CGFloat OBMenuBarWindowTitleBarHeight = 22.0;
+const CGFloat OBMenuBarWindowTitleBarDefaultHeight = 22.0;
 const CGFloat OBMenuBarWindowArrowHeight = 10.0;
 const CGFloat OBMenuBarWindowArrowWidth = 20.0;
 
@@ -86,6 +86,7 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
         hideWindowControlsWhenAttached = YES;
         isDetachable = YES;
         self.isAllowOrderOutWindowIfAppActive = YES;
+        self.windowTitleBarHeight = OBMenuBarWindowTitleBarDefaultHeight;
         [self initialSetup];
     }
     return self;
@@ -205,7 +206,7 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     // Position the content view
     NSRect contentViewFrame = [self.contentView frame];
     CGFloat currentTopMargin = NSHeight(self.frame) - NSHeight(contentViewFrame);
-    CGFloat titleBarHeight = OBMenuBarWindowTitleBarHeight + (self.attachedToMenuBar ? OBMenuBarWindowArrowHeight : 0) + 1;
+    CGFloat titleBarHeight = self.windowTitleBarHeight + (self.attachedToMenuBar ? OBMenuBarWindowArrowHeight : 0) + 1;
     CGFloat delta = titleBarHeight - currentTopMargin;
     contentViewFrame.size.height -= delta;
     [self.contentView setFrame:contentViewFrame];
@@ -417,9 +418,9 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
 - (NSRect)titleBarRect
 {
     return NSMakeRect(0,
-                      self.frame.size.height - OBMenuBarWindowTitleBarHeight - (self.attachedToMenuBar ? OBMenuBarWindowArrowHeight : 0),
+                      self.frame.size.height - self.windowTitleBarHeight - (self.attachedToMenuBar ? OBMenuBarWindowArrowHeight : 0),
                       self.frame.size.width,
-                      OBMenuBarWindowTitleBarHeight + (self.attachedToMenuBar ? OBMenuBarWindowArrowHeight : 0));
+                      self.windowTitleBarHeight + (self.attachedToMenuBar ? OBMenuBarWindowArrowHeight : 0));
 }
 
 - (NSRect)toolbarRect
@@ -427,9 +428,9 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     if (self.attachedToMenuBar)
     {
         return NSMakeRect(0,
-                          self.frame.size.height - OBMenuBarWindowTitleBarHeight - OBMenuBarWindowArrowHeight,
+                          self.frame.size.height - self.windowTitleBarHeight - OBMenuBarWindowArrowHeight,
                           self.frame.size.width,
-                          OBMenuBarWindowTitleBarHeight);
+                          self.windowTitleBarHeight);
     }
     else
     {
@@ -701,7 +702,7 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     NSRectFill(dirtyRect);
     
     // Erase the default title bar
-    CGFloat titleBarHeight = OBMenuBarWindowTitleBarHeight + (isAttached ? OBMenuBarWindowArrowHeight : 0);
+    CGFloat titleBarHeight = window.windowTitleBarHeight + (isAttached ? OBMenuBarWindowArrowHeight : 0);
     [[NSColor clearColor] set];
     NSRectFillUsingOperation([window titleBarRect], NSCompositeClear);
     
@@ -726,9 +727,9 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     NSPoint topRight = NSMakePoint(originX + width,
                                    originY + height - (isAttached ? OBMenuBarWindowArrowHeight : 0));
     NSPoint bottomLeft = NSMakePoint(originX,
-                                     originY + height - arrowHeight - OBMenuBarWindowTitleBarHeight);
+                                     originY + height - arrowHeight - window.windowTitleBarHeight);
     NSPoint bottomRight = NSMakePoint(originX + width,
-                                      originY + height - arrowHeight - OBMenuBarWindowTitleBarHeight);
+                                      originY + height - arrowHeight - window.windowTitleBarHeight);
     
     NSBezierPath *border = [NSBezierPath bezierPath];
     [border moveToPoint:arrowPointLeft];
@@ -751,11 +752,11 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     NSRect headingRect = NSMakeRect(originX,
                                     originY + height - titleBarHeight,
                                     width,
-                                    OBMenuBarWindowTitleBarHeight);
+                                    window.windowTitleBarHeight);
     NSRect titleBarRect = NSMakeRect(originX,
                                      originY + height - titleBarHeight,
                                      width,
-                                     OBMenuBarWindowTitleBarHeight + OBMenuBarWindowArrowHeight);
+                                     window.windowTitleBarHeight + OBMenuBarWindowArrowHeight);
     
     // Colors
     NSColor *bottomColor, *topColor, *topColorTransparent;
@@ -821,7 +822,7 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     // Draw separator line between the titlebar and the content view
     [[NSColor colorWithCalibratedWhite:0.5 alpha:1.0] set];
     NSRect separatorRect = NSMakeRect(originX,
-                                      originY + height - OBMenuBarWindowTitleBarHeight - (isAttached ? OBMenuBarWindowArrowHeight : 0) - 1,
+                                      originY + height - window.windowTitleBarHeight - (isAttached ? OBMenuBarWindowArrowHeight : 0) - 1,
                                       width,
                                       1);
     NSRectFill(separatorRect);

--- a/Classes/OBMenuBarWindow.m
+++ b/Classes/OBMenuBarWindow.m
@@ -438,6 +438,13 @@ const CGFloat OBMenuBarWindowArrowWidth = 20.0;
     }
 }
 
+#pragma mark - Property methods
+
+- (void)setWindowTitleBarHeight:(CGFloat)toTitleBarHeight {
+    _windowTitleBarHeight = toTitleBarHeight;
+    [self layoutContent];
+}
+
 #pragma mark - Active/key events
 
 - (BOOL)canBecomeKeyWindow


### PR DESCRIPTION
Option to don't orderOut the Window if the app is still active (another Window of the app is keyWindow).
Keeps compatibility with the original version, default mode works exactly the same.
